### PR TITLE
課題2-1：emailだけでなくnameでもログインできるようにする

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,7 +2,7 @@ class SessionsController < ApplicationController
   def new; end
 
   def create
-    user = User.find_by(email: params[:email])
+    user = User.find_by(email: params[:email_or_name]) || User.find_by(name: params[:email_or_name])
     if user.present? && user.authenticate(params[:password])
       session[:user_id] = user.id
       redirect_to questions_path, success: 'ログインしました'

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,7 +2,8 @@ class SessionsController < ApplicationController
   def new; end
 
   def create
-    user = User.find_by(email: params[:email])
+    user = User.find_by(email: params[:email_or_name]) || User.find_by(name: params[:email_or_name])
+
     if user.present? && user.authenticate(params[:password])
       session[:user_id] = user.id
       redirect_to questions_path, success: 'ログインしました'

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,8 +2,7 @@ class SessionsController < ApplicationController
   def new; end
 
   def create
-    user = User.find_by(email: params[:email_or_name]) || User.find_by(name: params[:email_or_name])
-
+    user = User.find_by(email: params[:email])
     if user.present? && user.authenticate(params[:password])
       session[:user_id] = user.id
       redirect_to questions_path, success: 'ログインしました'

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -4,8 +4,8 @@
       <div class="card-body">
         <%= form_with url: login_path do |f| %>
           <div class="form-group">
-            <%= f.label :email, 'メールアドレス' %>
-            <%= f.email_field :email, class: 'form-control' %>
+            <%= f.label :email_or_name, 'メールアドレスまたは名前' %>
+            <%= f.text_field :email_or_name, class: 'form-control' %>
           </div>
 
           <div class="form-group">

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -4,8 +4,8 @@
       <div class="card-body">
         <%= form_with url: login_path do |f| %>
           <div class="form-group">
-            <%= f.label :email, 'メールアドレス' %>
-            <%= f.email_field :email, class: 'form-control' %>
+            <%= f.label :email_or_name, 'メールアドレス' %>
+            <%= f.text_field :email_or_name, class: 'form-control' %>
           </div>
 
           <div class="form-group">

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -4,7 +4,7 @@
       <div class="card-body">
         <%= form_with url: login_path do |f| %>
           <div class="form-group">
-            <%= f.label :email_or_name, 'メールアドレス' %>
+            <%= f.label :email_or_name, 'メールアドレスまたは名前' %>
             <%= f.text_field :email_or_name, class: 'form-control' %>
           </div>
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -4,8 +4,8 @@
       <div class="card-body">
         <%= form_with url: login_path do |f| %>
           <div class="form-group">
-            <%= f.label :email_or_name, 'メールアドレスまたは名前' %>
-            <%= f.text_field :email_or_name, class: 'form-control' %>
+            <%= f.label :email, 'メールアドレス' %>
+            <%= f.email_field :email, class: 'form-control' %>
           </div>
 
           <div class="form-group">


### PR DESCRIPTION
### チケットへのリンク
[emailだけでなくnameでもログインできるようにする](https://github.com/moga-web/rails_practice_for_beginner/issues/1)
※このリポジトリ内に再現したIssueです
### やったこと
emailだけでなくnameでもログインできるようログインの入力formとSession#createを修正しました。
### スクリーンショット・動画
[![Image from Gyazo](https://i.gyazo.com/0bc77f5650e561c5523806c50b34af82.gif)](https://gyazo.com/0bc77f5650e561c5523806c50b34af82)
### 動作確認
nameのみの入力でログイン可能なことを確認しました。
### 相談・メモ
formをtext_fieldとしましたが問題ありませんか？
nameのformを作成した方が良かったでしょうか？